### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-zc.buildout==2.8.0
-setuptools==33.1.1
+setuptools==40.5.0
+zc.buildout==2.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-setuptools==40.5.0
-zc.buildout==2.12.2
+-r https://raw.githubusercontent.com/plone/buildout.coredev/5.2/requirements.txt


### PR DESCRIPTION
I needed to update the requirements to circumvent this issue:
```
[ale@emily plone.staticresources]$ ./bin/pip install -r requirements.txt 
Looking in links: file:///home/ale/.pip-wheelhouse
Collecting zc.buildout==2.8.0 (from -r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/a5/6c/17a727e7372eea17dc935c1b8becd904e1427466d6f270fd1390651efdc4/zc.buildout-2.8.0-py2.py3-none-any.whl
Collecting setuptools==33.1.1 (from -r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/e5/53/92a8ac9d252ec170d9197dcf988f07e02305a06078d7e83a41ba4e3ed65b/setuptools-33.1.1-py2.py3-none-any.whl
Installing collected packages: setuptools, zc.buildout
  Found existing installation: setuptools 40.5.0
    Uninstalling setuptools-40.5.0:
      Successfully uninstalled setuptools-40.5.0
Successfully installed setuptools-33.1.1 zc.buildout-2.8.0
[ale@emily plone.staticresources]$ ./bin/buildout -Nt 2 -c buildout.cfg 
Setting socket time out to 2 seconds.
Getting distribution for 'zc.buildout==2.11.2'.
While:
  Installing.
  Loading extensions.
  Getting distribution for 'zc.buildout==2.11.2'.
Error: Couldn't find a distribution for 'zc.buildout==2.11.2'.
```