### PR TITLE
Improve docs: add information about entry points

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,20 +2,20 @@
 plone.staticresources
 =====================
 
-Static JS and CSS resources for Plone.
+This add-on contains all static JavaScript and CSS resources used by Plone.
 
-
-This add-on contains all JavaScript and CSS resources used by Plone.
-
-Prior to Plone 5.2, they were located in ``static/`` directory of ``Products.CMFPlone`` package.
-
-Due to the specific tooling and workflows used to build frontend resources, and also the different maintenance and release needs of ``Products.CMFPlone`` itself, Plone static resources are now distributed in this package.
-For a complete list of reasons, read the `PLIP 1653 <https://github.com/plone/Products.CMFPlone/issues/1653>`_.
+Between Plone 5.0 and 5.1 these resources were located in ``static/``
+directory of ``Products.CMFPlone`` package. Starting with Plone 5.2 they're
+distributed in this independent package due to the specific tooling and
+workflows used to build frontend resources and also the different maintenance
+and release needs of ``Products.CMFPlone``. For a complete list of reasons,
+read `PLIP 1653 <https://github.com/plone/Products.CMFPlone/issues/1653>`_.
 
 .. note::
-
-  A note on yarn: we require the use of yarn, because it supports installing packages in a custom named directory, which npm does not (even using ``--prefix``, ``node_modules`` is hardcoded).
-  Our package directory is located at: ``src/plone/staticresources/static/components``.
+  A note on ``yarn``: we require the use of yarn, because it supports
+  installing packages in a custom named directory, which npm does not (even
+  using ``--prefix``, ``node_modules`` is hardcoded). Our package directory is
+  located at: ``src/plone/staticresources/static/components``.
 
 
 Target audience
@@ -23,57 +23,199 @@ Target audience
 
 This documentation aims at:
 
-Integrators and Developers
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+- **Theme Authors:** who want to change the look and feel of a Plone site and
+  need to:
 
-Who want to customize or maintain the front end of a Plone site for their customers:
+  - understand how to correctly bundle changes made into existing or new
+    frontend code
 
-- upgrade existing versions or install new ``npm`` packages.
+- **Integrators and Developers:** who want to customize or maintain the front
+  end of a Plone site for their customers:
 
-- integrate new JavaScript/CSS behavior, eventually wrapped in a ``pattern`` for optimal integration and reuse within Plone front end ecosystem.
+  - upgrade existing versions or install new ``npm`` packages.
 
+  - integrate new JavaScript/CSS behavior, eventually wrapped in a ``pattern``
+    for optimal integration and reuse within Plone front end ecosystem.
 
-Themer authors
-^^^^^^^^^^^^^^
-
-Who want to change the look and feel of a Plone site and need to:
-
-- understand how to correctly bundle changes from existing or new frontend code.
-
-
-Plone Core Developers
-^^^^^^^^^^^^^^^^^^^^^
-
-Who want to help enhance this add-on itself.
+- **Plone Core Developers:** who want to fix Plone bugs or enhance this add-on
 
 
 Compiling bundles
 -----------------
 
-The default Plone buildout configuration adds an executable in ``./bin/plone-compile-resources``.
-This script generates compiled bundles (normal, minified and respective maps) in ``plone/staticresources/static/`` or whereever the ``csscompilation`` and ``jscompilation`` attributes of the bundle registration in the resource registry points to.
-
-.. note::
-
-  You can see all the options of this executable by running ``./bin/plone-compile-resources --help``
-
+The front end resources in this package should be updated with the script
+called ``plone-compile-resources``, available in the ``bin`` directory of a
+default Plone buildout installation. This script compiles the final CSS and JS
+resources that will be served to end users.
 
 Building the ``plone`` bundle::
 
   ./bin/plone-compile-resources -b plone
 
-
 Building the ``plone-logged-in`` bundle::
 
   ./bin/plone-compile-resources -b plone-logged-in
+
+.. note::
+  You can see all the options of this executable by running
+  ``./bin/plone-compile-resources --help``
+
+Resources, Bundles, Patterns and the Resource Registry
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``plone-compile-resources`` script collects Resources from source packages
+(e.g. ``mockup``) and compiles them in ``plone/staticresources/static/`` into
+minified versions with source maps and, for JavaScript only, also into an
+unminified version. The output directory is configurable by using
+``csscompilation`` and ``jscompilation`` attributes of the bundle registration.
+
+Bundles are groups of resources. By default Plone comes configured to serve two
+main bundles:
+
+- ``plone``: containing JS and CSS used for anonymous visitors
+- ``plone-logged-in``: with additional resources for authenticated visitors,
+  e.g. for editor and management user interfaces
+
+Finally Plone encapsulates most of its CSS and JS into units called Patterns
+that live in the ``mockup`` package. Although Patterns provide their own
+registered Resources, those are not registered to Plone main bundles. Instead,
+they are imported through native LESS and Require JS "entry points" that live
+in ``plone.staticresource``:
+
+- `plone/staticresources/static/plone.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.js>`_
+- `plone/staticresources/static/plone.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.less>`_
+- `plone/staticresources/static/plone-logged-in.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.js>`_
+- `plone/staticresources/static/plone-logged-in.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.less>`_
+
+When editing a pattern (e.g. in ``mockup`` package), it's important to know for
+which bundle it's registered, which can be done by checking where it's imported
+in the entry points above. The bundle name will be useful as parameter for
+``plone-compile-resources`` script.
+
+.. note::
+  Patterns are also available as independent resources in ``Resource
+  Registries`` control panel but they are not registered to default Plone
+  bundles, which instead use the entry point approach. Pattern's resources may be
+  useful if needed to be injected in specific views.
+
+In production mode, Plone will serve static resources in URLs similar to:
+
+- http://localhost:8080/++plone++static/++unique++TIMESTAMP/plone-compiled.min.js
+- http://localhost:8080/++plone++static/++unique++TIMESTAMP/plone-compiled.css
+- http://localhost:8080/++plone++static/++unique++TIMESTAMP/plone-logged-in-compiled.min.js
+- http://localhost:8080/++plone++static/++unique++TIMESTAMP/plone-logged-in-compiled.css
+
+If Plone is configured to serve singles files, URLs will be similar to:
+
+- http://localhost:8080//++plone++production/++unique++TIMESTAMP/default.js
+- http://localhost:8080//++plone++production/++unique++TIMESTAMP/default.css
+
+In development mode, Plone will omit timestamp from path and serve fresh copies
+of the resources of the selected bundle(s). Those are compiled in-browser,
+on the fly for each page load and requested through XHR requests to URLs like:
+
+- http://localhost:8080/++resource++plone.js
+- http://localhost:8080/++plone++static/plone.less
+- http://localhost:8080/++resource++plone-logged-in.js
+- http://localhost:8080/++plone++static/plone-logged-in.less
+
+These entry points will then cause Patterns themselves to be loaded, through
+in-browser XHR requests to URLs like:
+
+- http://localhost:8080/Plone/++resource++mockup/livesearch/pattern.js
+- http://localhost:8080/Plone/++resource++mockup/livesearch/pattern.livesearch.less
+
+
+Development mode
+^^^^^^^^^^^^^^^^
+
+When fixing Plone bugs or improving functionality:
+
+- Dependencies upgrades (e.g. ``moment.js``) should be done in ``mockup`` and
+  after the PR is merged, propagated here (i.e. static resources needs to be
+  recompiled)
+- Likewise, CSS and JS should be developed not in ``plone.staticresources`` but
+  in their own package's source (for instance, in ``mockup``)
+- To see the new changes in the browser, enable ``Development Mode`` in
+  ``Resource Registries`` control panel. Next the desired bundle (that contains
+  the modified files) must be set to either "Develop JavaScript", "Develop CSS"
+  or both. This causes each of the bundle resources to be served individually,
+  easing development. In this case, bundle resources are served from the source
+  package (e.g. ``mockup``) instead of ``plone.staticresources``.
+- To identify which bundle contains the modified resource, see section
+  "Entry Points" below. Keep in mind the more bundles selected for development
+  mode the slower are page reloads, so it's recommended to select only what's
+  being developed.
+- Alternatively you may run ``./bin/plone-compile-resources`` between changes
+  and avoid Development Mode's in-browser compilation (fastest browser loading
+  time).
+
+
+Entry Points
+------------
+
+The current list of registered patterns for each entry point is available in:
+
+- `plone/staticresources/static/plone.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.js>`_
+- `plone/staticresources/static/plone.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.less>`_
+- `plone/staticresources/static/plone-logged-in.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.js>`_
+- `plone/staticresources/static/plone-logged-in.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.less>`_
+
+Here's a snapshot:
+
+For anonymous users
+^^^^^^^^^^^^^^^^^^^
+
++---------------------------------------+------------------------------------+
+| JS                                    | LESS                               |
++=======================================+====================================+
+| - jquery                              | - mockup-patterns-autotoc          |
+| - pat-registry                        | - mockup-patterns-livesearch       |
+| - mockup-patterns-base                | - mockup-patterns-markspeciallinks |
+| - mockup-patterns-autotoc             | - mockup-patterns-modal            |
+| - mockup-patterns-contentloader       | - mockup-patterns-pickadate        |
+| - mockup-patterns-cookietrigger       | - mockup-patterns-select2          |
+| - mockup-patterns-formautofocus       |                                    |
+| - mockup-patterns-formunloadalert     |                                    |
+| - mockup-patterns-livesearch          |                                    |
+| - mockup-patterns-markspeciallinks    |                                    |
+| - mockup-patterns-modal               |                                    |
+| - mockup-patterns-moment              |                                    |
+| - mockup-patterns-pickadate           |                                    |
+| - mockup-patterns-navigationmarker    |                                    |
+| - mockup-patterns-preventdoublesubmit |                                    |
+| - mockup-patterns-select2             |                                    |
+| - bootstrap-collapse                  |                                    |
+| - bootstrap-dropdown                  |                                    |
+| - bootstrap-tooltip                   |                                    |
++---------------------------------------+------------------------------------+
+
+For logged-in users
+^^^^^^^^^^^^^^^^^^^
+
++--------------------------------------------+--------------------------------+
+| JS                                         | LESS                           |
++============================================+================================+
+| - mockup-patterns-inlinevalidation         | - mockup-patterns-querystring  |
+| - mockup-patterns-querystring              | - mockup-patterns-recurrence   |
+| - mockup-patterns-recurrence               | - mockup-patterns-relateditems |
+| - mockup-patterns-relateditems             | - mockup-patterns-structure    |
+| - mockup-patterns-structure                | - mockup-patterns-tinymce      |
+| - mockup-patterns-structureupdater         | - mockup-patterns-upload       |
+| - mockup-patterns-textareamimetypeselector | - plone-patterns-toolbar       |
+| - mockup-patterns-tinymce                  |                                |
+| - plone-patterns-portletmanager            |                                |
+| - plone-patterns-toolbar                   |                                |
++--------------------------------------------+--------------------------------+
 
 
 Developing patterns
 -------------------
 
-All JavaScript code in this package is downloaded via ``yarn`` into ``src/plone/staticresources/static/components``.
-Nothing in that directory should be manually edited.
-If you need to fix something, do it in the original repository and eventually upgrade its version (next section).
+All JavaScript code in this package is downloaded via ``yarn`` into
+``src/plone/staticresources/static/components``. Nothing in that directory
+should be manually edited. If you need to fix something, do it in the original
+repository and eventually upgrade its version (next section).
 
 For Mockup, the original repository is: https://github.com/plone/mockup/
 
@@ -83,27 +225,36 @@ For Patternslib, visit: http://github.com/patternslib/Patterns
 How to upgrade the resources in this package
 --------------------------------------------
 
-- Increase ``npm`` package versions in ``package.json``, in sections ``dependencies`` or ``devDependencies``.
+1. Increase ``npm`` package versions in ``package.json``, in sections
+   ``dependencies`` or ``devDependencies``.
 
-- Run ``yarn upgrade`` (cannot be ``npm``).
+2. Run ``yarn upgrade`` (cannot be ``npm``)
 
-- Run ``./bin/plone-compile-resources -b plone``, ``./bin/plone-compile-resources -b plone-logged-in`` or whatever bundle you are going to build in your buildout's root directory.
+3. Run ``./bin/plone-compile-resources -b plone`` or
+   ``./bin/plone-compile-resources -b plone-logged-in`` (whichever bundle
+   you need to re-build).
 
-- Increase the ``last_compilation`` date in ``src/plone/staticresources/profiles/default/registry/bundles.xml``.
+4. Increase the ``last_compilation`` date in
+   ``src/plone/staticresources/profiles/default/registry/bundles.xml``.
 
-- Submit a PR and run the tests on Jenkins.
+5. Submit a PR and run the tests on Jenkins.
 
 
 How to generate the ``plone-compile-resources`` script
 ------------------------------------------------------
 
-The ``plone-compile-resources`` script can be used to compile bundles from the command line.
-In short, the script starts up a Plone instance, reads the resources and bundles configured in the registry and compiles a JS/CSS bundle based on that configuration. See ``plone-compile-resources --help`` for more information.
+The ``plone-compile-resources`` script can be used to compile bundles from the
+command line. In short, the script starts up a Plone instance, reads the
+resources and bundles configured in the registry and compiles a JS/CSS bundle
+based on that configuration. See ``plone-compile-resources --help`` for more
+information.
 
-When using buildout, ``plone-compile-resources`` script is automatically generated.
-If you use a custom buildout, you might need to add something similar to:
+When using buildout, ``plone-compile-resources`` script is automatically
+generated. If you use a custom buildout, you might need to add something
+similar to:
 
 .. code-block:: ini
+
   [buildout]
   parts =
     # ...
@@ -125,75 +276,50 @@ If you use a custom buildout, you might need to add something similar to:
 What has changed since Plone 5.1
 --------------------------------
 
-- All static resources - bundle resources, compiled bundles, external packages - from ``Products.CMFPlone.static`` have been moved here.
-
-- The bundle and resource registrations from ``Products.CMFPlone``'s ``dependencies`` profile have also been moved here.
-
-- The ``plone-compile-resources`` script has been moved here.
-
-- The ``thememapper`` bundle from ``plone.app.theming`` has been moved here.
-
-- The ``plone.resourceeditor`` bundle from ``plone.resourceeditor`` package has been moved here.
-
-- The ``toolbar`` pattern from ``Products.CMFPlone.static.toolbar`` has been moved to ``mockup`` package.
-
+- The ``toolbar`` pattern from ``Products.CMFPlone.static.toolbar`` has been
+  moved to ``mockup`` package.
 - ``mockup`` package now uses npm registry and yarn instead of bower.
 
+Besides the following has been moved in here:
 
-The resource registry and it's production and development modes
----------------------------------------------------------------
-
-The files in  the directory ``plone/staticresources/static/`` are served by Plone.
-In production mode Plone will combine the bundles (if configured) into single files.
-The URLs will be similar to:
-
-- http://localhost:8080//++plone++production/++unique++2019-01-08%2006%3A53%3A49.000248/default.js
-- http://localhost:8080//++plone++production/++unique++2019-01-08%2006%3A53%3A49.000248/default.css
-
-
-In development mode all bundles are served separately as non-compiled versions.
-The URLs will be similar to:
+- All static resources from ``Products.CMFPlone.static``: bundle resources,
+  compiled bundles, external packages
+- Bundle and resource registrations from ``Products.CMFPlone``'s
+  ``dependencies`` profile
+- ``plone-compile-resources`` script
+- ``thememapper`` bundle from ``plone.app.theming``
+- ``plone.resourceeditor`` bundle from ``plone.resourceeditor``
 
 
-- http://localhost:8080/++resource++plone.js
-- http://localhost:8080/++resource++plone-logged-in.js
-- http://localhost:8080/++plone++static/plone.less
-- http://localhost:8080//++plone++static/plone-logged-in.less
+More on the Resource Registry and its modes
+-------------------------------------------
 
-
-If you set the resource registry to development mode you can set "Develop JavaScript" and "Develop CSS" for individual bundles.
-Then each of the bundle resources are served individually, which makes it easy to develop on Mockup.
-In this case, the bundle resources are served from the Mockup package instead of plone.staticresources.
-The URLs will be similar to:
-
-http://localhost:8080/Plone/++resource++mockup/livesearch/pattern.js
-http://localhost:8080/Plone/++resource++mockup/livesearch/pattern.livesearch.less
-
-Have a look on how plone.staticresources and mockup register their resources:
+Have a look on how ``plone.staticresources`` and ``mockup`` register their
+resources:
 
 In ZCML:
 
-https://github.com/plone/mockup/blob/master/mockup/configure.zcml
-https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/configure.zcml
+- https://github.com/plone/mockup/blob/master/mockup/configure.zcml
+- https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/configure.zcml
 
 In the resource registry:
 
-https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/profiles/default/registry/bundles.xml
-https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/profiles/default/registry/resources.xml
-
+- https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/profiles/default/registry/bundles.xml
+- https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/profiles/default/registry/resources.xml
 
 For more information on the Plone resource registry see the documentation at:
 
-https://docs.plone.org/adapt-and-extend/theming/resourceregistry.html
+- https://docs.plone.org/adapt-and-extend/theming/resourceregistry.html
 
 
 Warning
 -------
 
-If you update ``r.js`` or ``less``, you willl need to manually re-apply a patch that gives us cache busting resource downloads so we can build through the web. See:
+If you update ``r.js`` or ``less``, you will need to manually re-apply a patch
+that gives us cache busting resource downloads so we can build through the web.
+See:
 
 - https://github.com/plone/Products.CMFPlone/commit/2d3865805efc6b72dce236eb68e502d8c57717b6
-
 - https://github.com/plone/Products.CMFPlone/commit/bd1f9ba99d1ad40bb7fe1c00eaa32b8884aae5e2
 
 

--- a/README.rst
+++ b/README.rst
@@ -4,18 +4,15 @@ plone.staticresources
 
 This add-on contains all static JavaScript and CSS resources used by Plone.
 
-Between Plone 5.0 and 5.1 these resources were located in ``static/``
-directory of ``Products.CMFPlone`` package. Starting with Plone 5.2 they're
-distributed in this independent package due to the specific tooling and
-workflows used to build frontend resources and also the different maintenance
-and release needs of ``Products.CMFPlone``. For a complete list of reasons,
-read `PLIP 1653 <https://github.com/plone/Products.CMFPlone/issues/1653>`_.
+Between Plone 5.0 and 5.1 these resources were located in ``static/`` directory of ``Products.CMFPlone`` package.
+Starting with Plone 5.2 they're distributed in this independent package due to the specific tooling and workflows used
+to build frontend resources and also the different maintenance and release needs of ``Products.CMFPlone``. For a
+complete list of reasons, read `PLIP 1653 <https://github.com/plone/Products.CMFPlone/issues/1653>`_.
 
 .. note::
-  A note on ``yarn``: we require the use of yarn, because it supports
-  installing packages in a custom named directory, which npm does not (even
-  using ``--prefix``, ``node_modules`` is hardcoded). Our package directory is
-  located at: ``src/plone/staticresources/static/components``.
+  A note on ``yarn``: we require the use of yarn, because it supports installing packages in a custom named directory,
+  which npm does not (even using ``--prefix``, ``node_modules`` is hardcoded). Our package directory is located at:
+  ``src/plone/staticresources/static/components``.
 
 
 Target audience
@@ -23,30 +20,26 @@ Target audience
 
 This documentation aims at:
 
-- **Theme Authors:** who want to change the look and feel of a Plone site and
-  need to:
+- **Theme Authors:** who want to change the look and feel of a Plone site and need to:
 
-  - understand how to correctly bundle changes made into existing or new
-    frontend code
+  - understand how to correctly bundle changes made into existing or new frontend code
 
-- **Integrators and Developers:** who want to customize or maintain the front
-  end of a Plone site for their customers:
+- **Integrators and Developers:** who want to customize or maintain the front end of a Plone site for their customers:
 
   - upgrade existing versions or install new ``npm`` packages.
 
-  - integrate new JavaScript/CSS behavior, eventually wrapped in a ``pattern``
-    for optimal integration and reuse within Plone front end ecosystem.
+  - integrate new JavaScript/CSS behavior, eventually wrapped in a ``pattern`` for optimal integration and reuse within
+    Plone front end ecosystem.
 
 - **Plone Core Developers:** who want to fix Plone bugs or enhance this add-on
 
 
-Compiling bundles
+Compiling Bundles
 -----------------
 
-The front end resources in this package should be updated with the script
-called ``plone-compile-resources``, available in the ``bin`` directory of a
-default Plone buildout installation. This script compiles the final CSS and JS
-resources that will be served to end users.
+The front end resources in this package should be updated with the script called ``plone-compile-resources``, available
+in the ``bin`` directory of a default Plone buildout installation. This script compiles the final CSS and JS resources
+that will be served to end users.
 
 Building the ``plone`` bundle::
 
@@ -57,46 +50,42 @@ Building the ``plone-logged-in`` bundle::
   ./bin/plone-compile-resources -b plone-logged-in
 
 .. note::
-  You can see all the options of this executable by running
-  ``./bin/plone-compile-resources --help``
+  You can see all the options of this executable by running ``./bin/plone-compile-resources --help``
 
 Resources, Bundles, Patterns and the Resource Registry
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``plone-compile-resources`` script collects Resources from source packages
-(e.g. ``mockup``) and compiles them in ``plone/staticresources/static/`` into
-minified versions with source maps and, for JavaScript only, also into an
-unminified version. The output directory is configurable by using
-``csscompilation`` and ``jscompilation`` attributes of the bundle registration.
+The ``plone-compile-resources`` script collects Resources from source packages (e.g. ``mockup``) and compiles them in
+``plone/staticresources/static/`` into minified versions with source maps and, for JavaScript only, also into an
+unminified version. The output directory is configurable by using ``csscompilation`` and ``jscompilation`` attributes of
+the bundle registration.
 
-Bundles are groups of resources. By default Plone comes configured to serve two
-main bundles:
+Bundles are groups of resources. By default Plone comes configured to serve two main bundles:
 
-- ``plone``: containing JS and CSS used for anonymous visitors
-- ``plone-logged-in``: with additional resources for authenticated visitors,
-  e.g. for editor and management user interfaces
+- ``plone``: containing JS and CSS used for anonymous visitors - ``plone-logged-in``: with additional resources for
+  authenticated visitors, e.g. for editor and management user interfaces
 
-Finally Plone encapsulates most of its CSS and JS into units called Patterns
-that live in the ``mockup`` package. Although Patterns provide their own
-registered Resources, those are not registered to Plone main bundles. Instead,
-they are imported through native LESS and Require JS "entry points" that live
-in ``plone.staticresource``:
+Finally Plone encapsulates most of its CSS and JS into units called Patterns that live in the ``mockup`` package.
+Although Patterns provide their own registered Resources, those are not registered to Plone main bundles. Instead, they
+are imported through native LESS and Require JS "entry points" that live in ``plone.staticresource``:
 
-- `plone/staticresources/static/plone.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.js>`_
-- `plone/staticresources/static/plone.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.less>`_
-- `plone/staticresources/static/plone-logged-in.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.js>`_
-- `plone/staticresources/static/plone-logged-in.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.less>`_
+- `plone/staticresources/static/plone.js
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.js>`_
+- `plone/staticresources/static/plone.less
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.less>`_
+- `plone/staticresources/static/plone-logged-in.js
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.js>`_
+- `plone/staticresources/static/plone-logged-in.less
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.less>`_
 
-When editing a pattern (e.g. in ``mockup`` package), it's important to know for
-which bundle it's registered, which can be done by checking where it's imported
-in the entry points above. The bundle name will be useful as parameter for
+When editing a pattern (e.g. in ``mockup`` package), it's important to know for which bundle it's registered, which can
+be done by checking where it's imported in the entry points above. The bundle name will be useful as parameter for
 ``plone-compile-resources`` script.
 
 .. note::
-  Patterns are also available as independent resources in ``Resource
-  Registries`` control panel but they are not registered to default Plone
-  bundles, which instead use the entry point approach. Pattern's resources may be
-  useful if needed to be injected in specific views.
+  Patterns are also available as independent resources in ``Resource Registries`` control panel but they are not
+  registered to default Plone bundles, which instead use the entry point approach. Pattern's resources may be useful if
+  needed to be injected in specific views.
 
 In production mode, Plone will serve static resources in URLs similar to:
 
@@ -110,17 +99,15 @@ If Plone is configured to serve singles files, URLs will be similar to:
 - http://localhost:8080//++plone++production/++unique++TIMESTAMP/default.js
 - http://localhost:8080//++plone++production/++unique++TIMESTAMP/default.css
 
-In development mode, Plone will omit timestamp from path and serve fresh copies
-of the resources of the selected bundle(s). Those are compiled in-browser,
-on the fly for each page load and requested through XHR requests to URLs like:
+In development mode, Plone will omit timestamp from path and serve fresh copies of the resources of the selected
+bundle(s). Those are compiled in-browser, on the fly for each page load and requested through XHR requests to URLs like:
 
 - http://localhost:8080/++resource++plone.js
 - http://localhost:8080/++plone++static/plone.less
 - http://localhost:8080/++resource++plone-logged-in.js
 - http://localhost:8080/++plone++static/plone-logged-in.less
 
-These entry points will then cause Patterns themselves to be loaded, through
-in-browser XHR requests to URLs like:
+These entry points will then cause Patterns themselves to be loaded, through in-browser XHR requests to URLs like:
 
 - http://localhost:8080/Plone/++resource++mockup/livesearch/pattern.js
 - http://localhost:8080/Plone/++resource++mockup/livesearch/pattern.livesearch.less
@@ -131,24 +118,19 @@ Development mode
 
 When fixing Plone bugs or improving functionality:
 
-- Dependencies upgrades (e.g. ``moment.js``) should be done in ``mockup`` and
-  after the PR is merged, propagated here (i.e. static resources needs to be
-  recompiled)
-- Likewise, CSS and JS should be developed not in ``plone.staticresources`` but
-  in their own package's source (for instance, in ``mockup``)
-- To see the new changes in the browser, enable ``Development Mode`` in
-  ``Resource Registries`` control panel. Next the desired bundle (that contains
-  the modified files) must be set to either "Develop JavaScript", "Develop CSS"
-  or both. This causes each of the bundle resources to be served individually,
-  easing development. In this case, bundle resources are served from the source
-  package (e.g. ``mockup``) instead of ``plone.staticresources``.
+- Dependencies upgrades (e.g. ``moment.js``) should be done in ``mockup`` and after the PR is merged, propagated here
+  (i.e. static resources needs to be recompiled)
+- Likewise, CSS and JS should be developed not in ``plone.staticresources`` but in their own package's source (for
+  instance, in ``mockup``)
+- To see the new changes in the browser, enable ``Development Mode`` in ``Resource Registries`` control panel. Next the
+  desired bundle (that contains the modified files) must be set to either "Develop JavaScript", "Develop CSS" or both.
+  This causes each of the bundle resources to be served individually, easing development. In this case, bundle
+  resources are served from the source package (e.g. ``mockup``) instead of ``plone.staticresources``.
 - To identify which bundle contains the modified resource, see section
-  "Entry Points" below. Keep in mind the more bundles selected for development
-  mode the slower are page reloads, so it's recommended to select only what's
-  being developed.
+  "Entry Points" below. Keep in mind the more bundles selected for development mode the slower are page reloads, so
+  it's recommended to select only what's being developed.
 - Alternatively you may run ``./bin/plone-compile-resources`` between changes
-  and avoid Development Mode's in-browser compilation (fastest browser loading
-  time).
+  and avoid Development Mode's in-browser compilation (fastest browser loading time).
 
 
 Entry Points
@@ -156,10 +138,14 @@ Entry Points
 
 The current list of registered patterns for each entry point is available in:
 
-- `plone/staticresources/static/plone.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.js>`_
-- `plone/staticresources/static/plone.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.less>`_
-- `plone/staticresources/static/plone-logged-in.js <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.js>`_
-- `plone/staticresources/static/plone-logged-in.less <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.less>`_
+- `plone/staticresources/static/plone.js
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.js>`_
+- `plone/staticresources/static/plone.less
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone.less>`_
+- `plone/staticresources/static/plone-logged-in.js
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.js>`_
+- `plone/staticresources/static/plone-logged-in.less
+  <https://github.com/plone/plone.staticresources/blob/master/src/plone/staticresources/static/plone-logged-in.less>`_
 
 Here's a snapshot:
 
@@ -208,14 +194,12 @@ For logged-in users
 | - plone-patterns-toolbar                   |                                |
 +--------------------------------------------+--------------------------------+
 
-
 Developing patterns
 -------------------
 
-All JavaScript code in this package is downloaded via ``yarn`` into
-``src/plone/staticresources/static/components``. Nothing in that directory
-should be manually edited. If you need to fix something, do it in the original
-repository and eventually upgrade its version (next section).
+All JavaScript code in this package is downloaded via ``yarn`` into ``src/plone/staticresources/static/components``.
+Nothing in that directory should be manually edited. If you need to fix something, do it in the original repository and
+eventually upgrade its version (next section).
 
 For Mockup, the original repository is: https://github.com/plone/mockup/
 
@@ -225,17 +209,14 @@ For Patternslib, visit: http://github.com/patternslib/Patterns
 How to upgrade the resources in this package
 --------------------------------------------
 
-1. Increase ``npm`` package versions in ``package.json``, in sections
-   ``dependencies`` or ``devDependencies``.
+1. Increase ``npm`` package versions in ``package.json``, in sections ``dependencies`` or ``devDependencies``.
 
 2. Run ``yarn upgrade`` (cannot be ``npm``)
 
 3. Run ``./bin/plone-compile-resources -b plone`` or
-   ``./bin/plone-compile-resources -b plone-logged-in`` (whichever bundle
-   you need to re-build).
+``./bin/plone-compile-resources -b plone-logged-in`` (whichever bundle you need to re-build).
 
-4. Increase the ``last_compilation`` date in
-   ``src/plone/staticresources/profiles/default/registry/bundles.xml``.
+4. Increase the ``last_compilation`` date in ``src/plone/staticresources/profiles/default/registry/bundles.xml``.
 
 5. Submit a PR and run the tests on Jenkins.
 
@@ -243,15 +224,12 @@ How to upgrade the resources in this package
 How to generate the ``plone-compile-resources`` script
 ------------------------------------------------------
 
-The ``plone-compile-resources`` script can be used to compile bundles from the
-command line. In short, the script starts up a Plone instance, reads the
-resources and bundles configured in the registry and compiles a JS/CSS bundle
-based on that configuration. See ``plone-compile-resources --help`` for more
-information.
+The ``plone-compile-resources`` script can be used to compile bundles from the command line. In short, the script starts
+up a Plone instance, reads the resources and bundles configured in the registry and compiles a JS/CSS bundle based on
+that configuration. See ``plone-compile-resources --help`` for more information.
 
-When using buildout, ``plone-compile-resources`` script is automatically
-generated. If you use a custom buildout, you might need to add something
-similar to:
+When using buildout, ``plone-compile-resources`` script is automatically generated. If you use a custom buildout, you
+might need to add something similar to:
 
 .. code-block:: ini
 
@@ -276,16 +254,13 @@ similar to:
 What has changed since Plone 5.1
 --------------------------------
 
-- The ``toolbar`` pattern from ``Products.CMFPlone.static.toolbar`` has been
-  moved to ``mockup`` package.
+- The ``toolbar`` pattern from ``Products.CMFPlone.static.toolbar`` has been moved to ``mockup`` package.
 - ``mockup`` package now uses npm registry and yarn instead of bower.
 
 Besides the following has been moved in here:
 
-- All static resources from ``Products.CMFPlone.static``: bundle resources,
-  compiled bundles, external packages
-- Bundle and resource registrations from ``Products.CMFPlone``'s
-  ``dependencies`` profile
+- All static resources from ``Products.CMFPlone.static``: bundle resources, compiled bundles, external packages
+- Bundle and resource registrations from ``Products.CMFPlone``'s ``dependencies`` profile
 - ``plone-compile-resources`` script
 - ``thememapper`` bundle from ``plone.app.theming``
 - ``plone.resourceeditor`` bundle from ``plone.resourceeditor``
@@ -294,8 +269,7 @@ Besides the following has been moved in here:
 More on the Resource Registry and its modes
 -------------------------------------------
 
-Have a look on how ``plone.staticresources`` and ``mockup`` register their
-resources:
+Have a look on how ``plone.staticresources`` and ``mockup`` register their resources:
 
 In ZCML:
 
@@ -315,9 +289,8 @@ For more information on the Plone resource registry see the documentation at:
 Warning
 -------
 
-If you update ``r.js`` or ``less``, you will need to manually re-apply a patch
-that gives us cache busting resource downloads so we can build through the web.
-See:
+If you update ``r.js`` or ``less``, you will need to manually re-apply a patch that gives us cache busting resource
+downloads so we can build through the web. See:
 
 - https://github.com/plone/Products.CMFPlone/commit/2d3865805efc6b72dce236eb68e502d8c57717b6
 - https://github.com/plone/Products.CMFPlone/commit/bd1f9ba99d1ad40bb7fe1c00eaa32b8884aae5e2


### PR DESCRIPTION
@thet, I've seen you removed line breaks from #13 but we need to restrict to [max 130 chars](https://github.com/plone/documentation/blob/5.1/about/contributing/documentation_styleguide.rst#line-length) so I rewrapped everything to more conservative 120, which is also the default in Prettier.