### PR TITLE
Added towncrier news for mockup PR #919

### DIFF
--- a/news/56.bugfix
+++ b/news/56.bugfix
@@ -1,0 +1,1 @@
+Fixed drag problem on click on sortable items in folder contents.


### PR DESCRIPTION
[Mockup PR 919](https://github.com/plone/mockup/pull/919) was merged a while ago and released in mockup 3.1.0
There was a PR to merge that in here #36, but was never merged. After that, a full compilation of the new mockup was done so the actual fix was included, but it was never tracked into plone.staticresources changelog, so I would suggest to track that now and close #36.
I'm pretty sure the fix is already in the latest release of plone.staticresources, so this change note would appear in a later release in che CHANGES file. I don't know if there's a way to fix that with towncrier.