### PR TITLE
Reconfiguring with plone/meta, try fixing ModuleNotFoundError

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/master/config/default
 [meta]
 template = "default"
-commit-id = "7032e1d4"
+commit-id = "a864b30f"
 
 [codespell]
 skip = "*.min.js,*.min.js.map,*.svg,yarn.lock,*.json,*/icons_country_flags.xml"

--- a/tox.ini
+++ b/tox.ini
@@ -32,17 +32,25 @@ commands =
     pre-commit run -a
 
 [testenv:dependencies]
-description = check if the package defines all its dependencies and generate a graph out of them
+description = check if the package defines all its dependencies
+skip_install = true
 deps =
+    build
     z3c.dependencychecker==2.11
+commands =
+    python -m build --sdist --no-isolation
+    dependencychecker
+
+[testenv:dependencies-graph]
+description = generate a graph out of the package's dependencies
+deps =
     pipdeptree==2.5.1
     graphviz  # optional dependency of pipdeptree
 commands =
-    dependencychecker
-    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
+    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
 [testenv:test]
-usedevelop = true
+use_develop = true
 constrain_package_deps = true
 set_env = ROBOT_BROWSER=headlesschrome
 deps =
@@ -54,7 +62,7 @@ extras =
     test
 
 [testenv:coverage]
-usedevelop = true
+use_develop = true
 constrain_package_deps = true
 set_env = ROBOT_BROWSER=headlesschrome
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    zope-testrunner --all --test-path={toxinidir} -s plone.staticresources {posargs}
+    zope-testrunner --all --test-path={toxinidir}/src -s plone.staticresources {posargs}
 extras =
     test
 
@@ -70,7 +70,7 @@ deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    coverage run {envbindir}/zope-testrunner --all --test-path={toxinidir} -s plone.staticresources {posargs}
+    coverage run {envbindir}/zope-testrunner --all --test-path={toxinidir}/src -s plone.staticresources {posargs}
     coverage report -m --format markdown
 extras =
     test


### PR DESCRIPTION
Hardly a difference anymore, but this is to check why `tox -e test` fails:

```
Module: src.plone.staticresources.tests.test_setup

ModuleNotFoundError: No module named 'src'
```

See for example this gh-actions run:
https://github.com/plone/plone.staticresources/actions/runs/4777441477/jobs/8493176778?pr=283