### PR TITLE
Update bundles interface

### DIFF
--- a/news/286.bugfix
+++ b/news/286.bugfix
@@ -1,0 +1,2 @@
+Update bundles interfaces (from CMFPlone to plone.base)
+[gforcada]

--- a/src/plone/staticresources/profiles/default/registry/bundles.xml
+++ b/src/plone/staticresources/profiles/default/registry/bundles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.IBundleRegistry"
            prefix="plone.bundles/plone"
   >
     <value key="enabled">True</value>
@@ -11,7 +11,7 @@
     <value key="load_defer">False</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.IBundleRegistry"
            prefix="plone.bundles/plone-fullscreen"
   >
     <value key="enabled">True</value>


### PR DESCRIPTION
The interface was moved from CMFPlone to plone.base.

As the package is only for Plone 6 and the interfaces were already moved in time for Plone 6, this should not be a breaking change 🤞🏾 