### PR TITLE
add custom @der-freitag/mockup package and remove @plone/mockup

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@der-freitag:registry=https://gitlab.com/api/v4/projects/52336424/packages/npm/
+//gitlab.com/api/v4/projects/52336424/packages/npm/:_authToken=glpat-8VNU5exB5rV3z9b85uNF

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,16 @@ Changelog
 
 .. towncrier release notes start
 
+2.1.7.post0 (2024-02-05)
+------------------------
+
+Bug fixes:
+
+
+- Use final interface locations, otherwise it fails
+  [gforcada]
+
+
 2.1.7 (2023-09-19)
 ------------------
 

--- a/news/+ignore.bugfix
+++ b/news/+ignore.bugfix
@@ -1,2 +1,0 @@
-Use final interface locations, otherwise it fails
-[gforcada]

--- a/news/+ignore.bugfix
+++ b/news/+ignore.bugfix
@@ -1,0 +1,2 @@
+Use final interface locations, otherwise it fails
+[gforcada]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "stats": "NODE_ENV=production webpack --config webpack.config.js --json > stats.json"
     },
     "dependencies": {
-        "@plone/mockup": "5.1.5",
+        "@der-freitag/mockup": "^5.1.4",
         "bootstrap-icons": "1.11.1",
         "svg-country-flags": "git+https://github.com/hampusborgos/country-flags.git"
     },

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = (
 
 setup(
     name="plone.staticresources",
-    version="2.1.7.post0",
+    version="2.1.7.post1.dev0",
     description="Static resources for Plone",
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = (
 
 setup(
     name="plone.staticresources",
-    version="2.1.8.dev0",
+    version="2.1.7.post0",
     description="Static resources for Plone",
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/src/plone/staticresources/upgrades/profiles/202/registry.xml
+++ b/src/plone/staticresources/upgrades/profiles/202/registry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
 
-  <records interface="Products.CMFPlone.interfaces.IResourceRegistry"
+  <records interface="plone.base.interfaces.resources.IResourceRegistry"
            prefix="plone.resources/plone-fontello"
   >
     <value key="css">
@@ -9,7 +9,7 @@
     </value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IResourceRegistry"
+  <records interface="plone.base.interfaces.resources.IResourceRegistry"
            prefix="plone.resources/plone-glyphicons"
   >
     <value key="css">
@@ -17,7 +17,7 @@
     </value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-fontello"
   >
     <value key="depends">plone</value>
@@ -32,7 +32,7 @@
     <value key="last_compilation">2021-03-17 15:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-glyphicons"
   >
     <value key="depends">plone</value>

--- a/src/plone/staticresources/upgrades/profiles/204/registry/bundles.xml
+++ b/src/plone/staticresources/upgrades/profiles/204/registry/bundles.xml
@@ -2,79 +2,79 @@
 <registry>
 
   <!-- Bundles -->
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-base"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-moment"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-logged-in"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-editor-tools"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-tinymce"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-datatables"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-legacy"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-fontello"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-glyphicons"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/resourceregistry"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/thememapper"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/filemanager"
   >
     <value key="last_compilation">2021-04-22 17:00:00</value>

--- a/src/plone/staticresources/upgrades/profiles/205/registry/bundles.xml
+++ b/src/plone/staticresources/upgrades/profiles/205/registry/bundles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-legacy"
            purge="False"
   >

--- a/src/plone/staticresources/upgrades/profiles/206/registry/bundles.xml
+++ b/src/plone/staticresources/upgrades/profiles/206/registry/bundles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-legacy"
            purge="False"
   >

--- a/src/plone/staticresources/upgrades/profiles/208/registry/resources.xml
+++ b/src/plone/staticresources/upgrades/profiles/208/registry/resources.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
-  <records interface="Products.CMFPlone.interfaces.IResourceRegistry"
+  <records interface="plone.base.interfaces.resources.IResourceRegistry"
            prefix="plone.resources/datatables.net-autofill"
   >
     <value key="js">++plone++static/components/datatables.net-autofill/js/dataTables.autoFill.js</value>

--- a/src/plone/staticresources/upgrades/profiles/210/registry.xml
+++ b/src/plone/staticresources/upgrades/profiles/210/registry.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/jquery"
            purge="False"
   >
     <value key="jscompilation">++plone++static/bundle-plone/jquery-remote.min.js</value>
   </records>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/bootstrap-js"
            purge="False"
   >

--- a/src/plone/staticresources/upgrades/profiles/211/registry.xml
+++ b/src/plone/staticresources/upgrades/profiles/211/registry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
 
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="plone.base.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-fullscreen"
   >
     <value key="enabled">True</value>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,45 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@der-freitag/mockup@^5.1.4":
+  version "5.1.4"
+  resolved "https://gitlab.com/api/v4/projects/52336424/packages/npm/@der-freitag/mockup/-/@der-freitag/mockup-5.1.4.tgz#922515485840f3e2995eec0c8e641525ee33a38b"
+  integrity sha1-kiUVSFhA8+KZXuwMjmQVJe4zo4s=
+  dependencies:
+    "@11ty/eleventy-upgrade-help" "2"
+    "@patternslib/pat-code-editor" "4.0.1"
+    "@patternslib/patternslib" "^9.9.5"
+    backbone "1.4.1"
+    backbone.paginator "2.0.8"
+    bootstrap "5.3.1"
+    bootstrap-icons "1.10.5"
+    cs-jqtree-contextmenu "0.1.0"
+    datatables.net "1.12.1"
+    datatables.net-bs5 "1.12.1"
+    datatables.net-buttons "2.2.3"
+    datatables.net-buttons-bs5 "2.2.3"
+    datatables.net-colreorder "1.5.6"
+    datatables.net-colreorder-bs5 "1.5.6"
+    datatables.net-fixedcolumns "4.1.0"
+    datatables.net-fixedcolumns-bs5 "4.1.0"
+    datatables.net-fixedheader "3.2.4"
+    datatables.net-fixedheader-bs5 "3.2.4"
+    datatables.net-rowreorder "1.2.8"
+    datatables.net-rowreorder-bs5 "1.2.8"
+    datatables.net-select "1.4.0"
+    datatables.net-select-bs5 "1.4.0"
+    dropzone "4.3.0"
+    jqtree "1.7.0"
+    jquery "^3.7.0"
+    jquery-form "4.3.0"
+    jquery.browser "0.1.0"
+    js-cookie "^3.0.5"
+    select2 "git+https://github.com/ivaynberg/select2.git#3.5.4"
+    sortablejs "^1.15.0"
+    tinymce "^5.10.7"
+    tinymce-i18n "^22.12.27"
+    underscore "^1.13.6"
+
 "@discoveryjs/json-ext@0.5.7", "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.2":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -1831,45 +1870,6 @@
     slides "git+https://github.com/Patternslib/slides.git"
     spectrum-colorpicker "^1.8.0"
     tippy.js "^6.3.7"
-
-"@plone/mockup@5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@plone/mockup/-/mockup-5.1.5.tgz#dcac0f6065c3a703a553958fcbcdd8efec6164ae"
-  integrity sha512-iClPSsImXmd+V1KqkCLOOMM192lRGpydTQLlJezld+3JPc4glycwCdUw3HvD7WUqWdo+hj8xRJYPzj5awhTzAA==
-  dependencies:
-    "@11ty/eleventy-upgrade-help" "2"
-    "@patternslib/pat-code-editor" "4.0.1"
-    "@patternslib/patternslib" "^9.9.5"
-    backbone "1.4.1"
-    backbone.paginator "2.0.8"
-    bootstrap "5.3.2"
-    bootstrap-icons "1.11.1"
-    cs-jqtree-contextmenu "0.1.0"
-    datatables.net "1.12.1"
-    datatables.net-bs5 "1.12.1"
-    datatables.net-buttons "2.2.3"
-    datatables.net-buttons-bs5 "2.2.3"
-    datatables.net-colreorder "1.5.6"
-    datatables.net-colreorder-bs5 "1.5.6"
-    datatables.net-fixedcolumns "4.1.0"
-    datatables.net-fixedcolumns-bs5 "4.1.0"
-    datatables.net-fixedheader "3.2.4"
-    datatables.net-fixedheader-bs5 "3.2.4"
-    datatables.net-rowreorder "1.2.8"
-    datatables.net-rowreorder-bs5 "1.2.8"
-    datatables.net-select "1.4.0"
-    datatables.net-select-bs5 "1.4.0"
-    dropzone "4.3.0"
-    jqtree "1.7.0"
-    jquery "^3.7.0"
-    jquery-form "4.3.0"
-    jquery.browser "0.1.0"
-    js-cookie "^3.0.5"
-    select2 "git+https://github.com/ivaynberg/select2.git#3.5.4"
-    sortablejs "^1.15.0"
-    tinymce "^5.10.7"
-    tinymce-i18n "^22.12.27"
-    underscore "^1.13.6"
 
 "@pnpm/config.env-replace@^1.1.0":
   version "1.1.0"
@@ -2945,15 +2945,20 @@ bonjour-service@^1.0.11:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.5"
 
+bootstrap-icons@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.10.5.tgz#5a1bbb1bb2212397d416587db1d422cc9501847c"
+  integrity sha512-oSX26F37V7QV7NCE53PPEL45d7EGXmBgHG3pDpZvcRaKVzWMqIRL9wcqJUyEha1esFtM3NJzvmxFXDxjJYD0jQ==
+
 bootstrap-icons@1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.11.1.tgz#79e32494871d8c98e9d14f4bcdc278cee9b1dafd"
   integrity sha512-F0DDp7nKUX+x/QtpfRZ+XHFya60ng9nfdpdS59vDDfs4Uhuxp7zym/QavMsu/xx51txkoM9eVmpE7D08N35blw==
 
-bootstrap@5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.2.tgz#97226583f27aae93b2b28ab23f4c114757ff16ae"
-  integrity sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==
+bootstrap@5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.1.tgz#8ca07040ad15d7f75891d1504cf14c5dedfb1cfe"
+  integrity sha512-jzwza3Yagduci2x0rr9MeFSORjcHpt0lRZukZPZQJT1Dth5qzV7XcgGqYzi39KGAVYR8QEDVoO0ubFKOxzMG+g==
 
 boxen@^7.0.0:
   version "7.1.1"


### PR DESCRIPTION
Custom package @der-freitag/mockup is a fork of @plone/mockup. 

Published on gitlab registry, it is disabling tinymce so we can add our oun configuration.