### PR TITLE
Add missing plone.icon.plone-rearrange and plone.icon.plone-selection.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,6 @@ exclude package.json
 exclude .prettierrc.json
 exclude Makefile
 exclude babel.config.js
-exclude requirements.txt
 exclude webpack.config.js
 exclude pnpm-lock.yaml
 exclude pnpm-workspace.yaml

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,19 @@ clean:
 	# remove mockup from sources
 	rm -Rf node_modules
 	rm -Rf src/plone/staticresources/static/bundle-plone/*
+	rm -Rf .venv
 
 install: clean
 	$(PNPM) install
+	`which python3` -m venv .venv
+	./.venv/bin/pip install lxml
 
 .PHONY: build
 build: install
 	$(PNPM) run build
 
 .PHONY: update-icons
-update-icons:
-	(cd src/plone/staticresources/_scripts && `which python3` register_icons.py)
-	(cd src/plone/staticresources/_scripts && `which python3` register_flag_icons.py)
-	(cd src/plone/staticresources/_scripts && `which python3` iconmap_json.py)
+update-icons: install
+	./.venv/bin/python src/plone/staticresources/_scripts/register_icons.py
+	./.venv/bin/python src/plone/staticresources/_scripts/register_flag_icons.py
+	./.venv/bin/python src/plone/staticresources/_scripts/iconmap_json.py

--- a/news/+add-missing-icons.bugfix.1.rst
+++ b/news/+add-missing-icons.bugfix.1.rst
@@ -1,0 +1,1 @@
+Remove unused requirements.txt file.

--- a/news/+add-missing-icons.bugfix.2.rst
+++ b/news/+add-missing-icons.bugfix.2.rst
@@ -1,0 +1,1 @@
+Update scripts: Use pathlib to construct filesystem paths.

--- a/news/+add-missing-icons.bugfix.3.rst
+++ b/news/+add-missing-icons.bugfix.3.rst
@@ -1,0 +1,4 @@
+Update scripts: Improve update-icons target.
+
+Use a virtual environment and install lxml for the update-icons target to make
+it work without manually installing dependencies.

--- a/news/+add-missing-icons.bugfix.rst
+++ b/news/+add-missing-icons.bugfix.rst
@@ -1,0 +1,3 @@
+Add missing icons to the registry.
+Also provide a upgrade utility to add any missing icons in the future.
+@thet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
--r https://raw.githubusercontent.com/plone/buildout.coredev/6.1/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "lxml",
         "plone.base",
         "plone.resource",
+        "zope.component",
         "zope.i18nmessageid",
         "zope.interface",
     ],

--- a/src/plone/staticresources/_scripts/iconmap_json.py
+++ b/src/plone/staticresources/_scripts/iconmap_json.py
@@ -1,18 +1,23 @@
 from lxml import etree
+from pathlib import Path
 
 import json
 
+module_dir = Path(__file__).parent
+base_path = module_dir / ".." / "profiles" / "default" / "registry"
+
+
 FILES = [
-    r"../profiles/default/registry/icons_bootstrap.xml",
-    r"../profiles/default/registry/icons_contenttype.xml",
-    r"../profiles/default/registry/icons_country_flags.xml",
-    r"../profiles/default/registry/icons_language_flags.xml",
-    r"../profiles/default/registry/icons_mimetype.xml",
-    r"../profiles/default/registry/icons_plone.xml",
-    r"../profiles/default/registry/icons_toolbar.xml",
+    base_path / "icons_bootstrap.xml",
+    base_path / "icons_contenttype.xml",
+    base_path / "icons_country_flags.xml",
+    base_path / "icons_language_flags.xml",
+    base_path / "icons_mimetype.xml",
+    base_path / "icons_plone.xml",
+    base_path / "icons_toolbar.xml",
 ]
 
-PATH_ICONMAP = "../static/iconmap.json"
+PATH_ICONMAP = module_dir / ".." / "static" / "iconmap.json"
 
 
 def main():

--- a/src/plone/staticresources/_scripts/register_flag_icons.py
+++ b/src/plone/staticresources/_scripts/register_flag_icons.py
@@ -1,13 +1,14 @@
-import json
-import os
+from pathlib import Path
 
-this_dir = os.path.dirname(os.path.realpath(__file__))
+import json
+
+this_dir = Path(__file__).parent
 
 # Part Register Country Flag Icons
-DATA_FILE_COUNTRY = "{dir}/../static/icons-country-flags/countries.json".format(
-    dir=this_dir
+DATA_FILE_COUNTRY = this_dir / ".." / "static" / "icons-country-flags/countries.json"
+OUTPUT_FILE_COUNTRY = (
+    this_dir / ".." / "profiles" / "default" / "registry" / "icons_country_flags.xml"
 )
-OUTPUT_FILE_COUNTRY = f"{this_dir}/../profiles/default/registry/icons_country_flags.xml"
 
 DEFAULT_PATTERN_COUNTRY = """
   <record name="plone.icon.countryflag">
@@ -29,11 +30,9 @@ PATTERN_COUNTRY = """
 
 
 # Part Register Language Flag Icons
-DATA_FILE_LANGUAGE = "{dir}/../static/icons-language-flags/languages.json".format(
-    dir=this_dir
-)
+DATA_FILE_LANGUAGE = this_dir / ".." / "static" / "icons-language-flags/languages.json"
 OUTPUT_FILE_LANGUAGE = (
-    f"{this_dir}/../profiles/default/registry/icons_language_flags.xml"
+    this_dir / ".." / "profiles" / "default" / "registry" / "icons_language_flags.xml"
 )
 
 DEFAULT_PATTERN_LANGUAGE = """

--- a/src/plone/staticresources/_scripts/register_icons.py
+++ b/src/plone/staticresources/_scripts/register_icons.py
@@ -1,10 +1,12 @@
+from pathlib import Path
+
 import os
 
-this_dir = os.path.dirname(os.path.realpath(__file__))
+this_dir = Path(__file__).parent
 
-ICONS_DIR = f"{this_dir}/../static/icons-bootstrap"
-OUTPUT_FILE = "{dir}/../profiles/default/registry/icons_bootstrap.xml".format(
-    dir=this_dir
+ICONS_DIR = this_dir / ".." / "static" / "icons-bootstrap"
+OUTPUT_FILE = (
+    this_dir / ".." / "profiles" / "default" / "registry" / "icons_bootstrap.xml"
 )
 
 registry_template = """<?xml version="1.0" encoding="utf-8"?>

--- a/src/plone/staticresources/profiles/default/metadata.xml
+++ b/src/plone/staticresources/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>216</version>
+  <version>217</version>
   <dependencies>
     <dependency>profile-plone.resource:default</dependency>
   </dependencies>

--- a/src/plone/staticresources/upgrades/217.zcml
+++ b/src/plone/staticresources/upgrades/217.zcml
@@ -1,0 +1,17 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:gs="http://namespaces.zope.org/genericsetup"
+    >
+
+  <gs:upgradeSteps
+      profile="plone.staticresources:default"
+      source="216"
+      destination="217"
+      >
+    <gs:upgradeStep
+        title="Add missing icons"
+        handler=".update_all_icons"
+        />
+  </gs:upgradeSteps>
+
+</configure>

--- a/src/plone/staticresources/upgrades/__init__.py
+++ b/src/plone/staticresources/upgrades/__init__.py
@@ -1,0 +1,28 @@
+from lxml import etree
+from plone.registry.field import TextLine
+from plone.registry.interfaces import IRegistry
+from plone.registry.record import Record
+from plone.staticresources._scripts.iconmap_json import FILES
+from zope.component import getUtility
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def update_all_icons(context):
+    registry = getUtility(IRegistry)
+
+    for file in FILES:
+        root = etree.parse(file)
+        for record in root.xpath("//record"):
+            key = record.get("name")
+            val = record.xpath("value")[0].text
+            _val = registry.get(key)
+            if not _val:
+                # set
+                title = record.xpath("field/title")[0].text
+                field = TextLine(title=title)
+                record = Record(field=field, value=val)
+                registry.records[key] = record
+                logger.info("Add icon %s", key)

--- a/src/plone/staticresources/upgrades/configure.zcml
+++ b/src/plone/staticresources/upgrades/configure.zcml
@@ -27,5 +27,6 @@
   <include file="214.zcml" />
   <include file="215.zcml" />
   <include file="216.zcml" />
+  <include file="217.zcml" />
 
 </configure>


### PR DESCRIPTION
After a Plone 5 inline migration some icons were missing, especially visible in folder_contents:

<img width="2071" height="124" alt="image" src="https://github.com/user-attachments/assets/851a7083-b6cd-4e12-a5a9-ce010f7f4e1a" />

After this upgrade:

<img width="2071" height="112" alt="image" src="https://github.com/user-attachments/assets/0a36f94f-82a5-46dc-96ac-59c8eebab166" />


Update:

- The upgrade step now checks for all missing icons. Only those which are missing are imported.


Some things to consider:
- [x] This upgrade step overrides any customization which might eventually have been done. So, if someone changed the plone-rearrange or plone-selection icons, they are now re-set.
It would be better to do this upgrade in Python code and check if some midifications were done before this upgrade step is applied.
- [x] I did not check for any other missing icons. Those were the two items which were apparent.

## Update

There was this issue: https://github.com/plone/Products.CMFPlone/issues/3838
And even a PR, which I did miss: https://github.com/plone/plone.staticresources/pull/337