### PR TITLE
Raise metadata.xml version to 300 to separate that from the 3.0.x branch.

### DIFF
--- a/news/+raise-metadata-version.internal.rst
+++ b/news/+raise-metadata-version.internal.rst
@@ -1,0 +1,2 @@
+Raise metadata.xml version to 300 to separate that from the 3.0.x branch.
+@thet

--- a/src/plone/staticresources/profiles/default/metadata.xml
+++ b/src/plone/staticresources/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>217</version>
+  <version>300</version>
   <dependencies>
     <dependency>profile-plone.resource:default</dependency>
   </dependencies>


### PR DESCRIPTION
the 3.0.x branch is at 216. This is necessary to not accidentality mess up upgrade steps from the 3.0.x branch with news ones from master.